### PR TITLE
Add quit bindings to evil-collection ibuffer

### DIFF
--- a/evil-collection-ibuffer.el
+++ b/evil-collection-ibuffer.el
@@ -79,7 +79,7 @@
     "`" 'ibuffer-switch-format
     "-" 'ibuffer-add-to-tmp-hide
     "+" 'ibuffer-add-to-tmp-show
-    "q" 'ibuffer-bury-buffer
+    "b" 'ibuffer-bury-buffer
     (kbd ",") 'ibuffer-toggle-sorting-mode
     (kbd "o i") 'ibuffer-invert-sorting
     (kbd "o a") 'ibuffer-do-sort-by-alphabetic
@@ -178,7 +178,12 @@
     (kbd "C-o") 'ibuffer-visit-buffer-other-window-noselect
     (kbd "M-o") 'ibuffer-visit-buffer-1-window
     (kbd "gv") 'ibuffer-do-view
-    (kbd "gV") 'ibuffer-do-view-horizontally))
+    (kbd "gV") 'ibuffer-do-view-horizontally
+
+    ;; Quit
+    "q" 'quit-window
+    "ZZ" 'quit-window
+    "ZQ" 'quit-window))
 
 (provide 'evil-collection-ibuffer)
 ;;; evil-collection-ibuffer.el ends here

--- a/evil-collection-ibuffer.el
+++ b/evil-collection-ibuffer.el
@@ -79,7 +79,7 @@
     "`" 'ibuffer-switch-format
     "-" 'ibuffer-add-to-tmp-hide
     "+" 'ibuffer-add-to-tmp-show
-    "b" 'ibuffer-bury-buffer
+    "X" 'ibuffer-bury-buffer
     (kbd ",") 'ibuffer-toggle-sorting-mode
     (kbd "o i") 'ibuffer-invert-sorting
     (kbd "o a") 'ibuffer-do-sort-by-alphabetic
@@ -167,7 +167,6 @@
     (kbd "r") 'ibuffer-do-replace-regexp
     (kbd "V") 'ibuffer-do-revert
     (kbd "W") 'ibuffer-do-view-and-eval
-    (kbd "X") 'ibuffer-do-shell-command-pipe
 
     (kbd "K") 'ibuffer-do-kill-lines
     (kbd "yf") 'ibuffer-copy-filename-as-kill


### PR DESCRIPTION
Per [the readme](https://github.com/jojojames/evil-collection#quitting-q-zq-zz), `q` is used for quitting when macros are not useful. Binding `q` to bury buffer is a bad decision since it goes against this philosophy, and there's already a default binding for bury buffer - `b`. Since `b` dosen't make too much sense in ibuffer mode, it makes sense to use this key in evil mode too. 

Let me know if you think differently, while I'm open to binding other keys to bury-buffer, I think `q` should be reserved for quitting to keep the experience seamless.