### PR TITLE
anaconda-mode-view-mode-map doesn't exist; use anaconda-view-mode-map instead

### DIFF
--- a/evil-collection-anaconda-mode.el
+++ b/evil-collection-anaconda-mode.el
@@ -34,7 +34,10 @@
   ;; Bindings don't seem to be set the first time.
   (add-hook 'anaconda-mode-hook #'evil-normalize-keymaps)
 
-  (evil-define-key 'normal anaconda-view-mode-map
+  ;; latest anaconda uses `anaconda-view-mode-map'; anaconda stable
+  ;; uses `anaconda-mode-view-mode-map'
+  (evil-define-key 'normal (or anaconda-view-mode-map
+			       anaconda-mode-view-mode-map)
     "gj" 'next-error-no-select
     "gk" 'previous-error-no-select
     (kbd "C-j") 'next-error-no-select

--- a/evil-collection-anaconda-mode.el
+++ b/evil-collection-anaconda-mode.el
@@ -34,7 +34,7 @@
   ;; Bindings don't seem to be set the first time.
   (add-hook 'anaconda-mode-hook #'evil-normalize-keymaps)
 
-  (evil-define-key 'normal anaconda-mode-view-mode-map
+  (evil-define-key 'normal anaconda-view-mode-map
     "gj" 'next-error-no-select
     "gk" 'previous-error-no-select
     (kbd "C-j") 'next-error-no-select

--- a/evil-collection-anaconda-mode.el
+++ b/evil-collection-anaconda-mode.el
@@ -36,8 +36,9 @@
 
   ;; latest anaconda uses `anaconda-view-mode-map'; anaconda stable
   ;; uses `anaconda-mode-view-mode-map'
-  (evil-define-key 'normal (or anaconda-view-mode-map
-			       anaconda-mode-view-mode-map)
+  (evil-define-key 'normal (if (boundp 'anaconda-mode-view-mode-map)
+			       anaconda-mode-view-mode-map
+			     anaconda-view-mode-map)
     "gj" 'next-error-no-select
     "gk" 'previous-error-no-select
     (kbd "C-j") 'next-error-no-select


### PR DESCRIPTION
I don't know whether `evil-collection` is meant for the stable packages in melpa. If it is, then reject this PR because the current setup is correct. However the latest anaconda-mode on melpa renamed `anaconda-mode-view-mode-map` to `anaconda-view-mode-map`.