### PR TITLE
Remove debugs in evil-collection-diff-mode.el

### DIFF
--- a/evil-collection-diff-mode.el
+++ b/evil-collection-diff-mode.el
@@ -42,10 +42,8 @@
   "Make read-only in motion state, writable in normal state."
   (if buffer-read-only
       (progn
-        (evil-motion-state)
-        (message "Evil Diff: enter motion state"))
-    (evil-normal-state)
-    (message "Evil Diff: enter normal state")))
+        (evil-motion-state))
+    (evil-normal-state)))
 
 (defun evil-collection-diff-toggle-setup ()
   "Toggle visiting diff buffers in motion state."


### PR DESCRIPTION
I often see the `Evil Diff: enter motion state` message while using magit and vdiff. Seems to me that these messages were meant for debugging purposes, hence this PR.

Thank you!