### PR TITLE
evil-collection-delete-operators: fix typo

### DIFF
--- a/evil-collection.el
+++ b/evil-collection.el
@@ -179,7 +179,7 @@ instance:
 
 (defvar evil-collection-delete-operators '(evil-delete
                                            evil-cp-delete
-                                           vil-sp-delete
+                                           evil-sp-delete
                                            lispyville-delete)
   "List of delete operators.")
 


### PR DESCRIPTION
Fix typo, refs https://github.com/jojojames/evil-collection/pull/91#issuecomment-366544730