### PR TITLE
Normalize mark bindings

### DIFF
--- a/evil-collection-bookmark.el
+++ b/evil-collection-bookmark.el
@@ -45,8 +45,6 @@
     "1" 'bookmark-bmenu-1-window
     "x" 'bookmark-bmenu-execute-deletions
     "d" 'bookmark-bmenu-delete
-    "u" 'bookmark-bmenu-unmark
-    "m" 'bookmark-bmenu-mark
     "/" 'bookmark-bmenu-search
     "r" 'bookmark-bmenu-rename
     "R" 'bookmark-bmenu-relocate
@@ -58,6 +56,10 @@
     "W" 'bookmark-bmenu-locate
     "E" 'bookmark-bmenu-edit-annotation
     "D" 'bookmark-bmenu-delete-backwards
+
+    ;; mark
+    "u" 'bookmark-bmenu-unmark
+    "m" 'bookmark-bmenu-mark
 
     ;; open
     "o" 'bookmark-bmenu-select

--- a/evil-collection-buff-menu.el
+++ b/evil-collection-buff-menu.el
@@ -78,11 +78,6 @@ When called interactively prompt for MARK;  RET remove all marks."
     "go" 'Buffer-menu-this-window
     "gO" 'Buffer-menu-other-window
     "d" 'Buffer-menu-delete
-    "u" 'Buffer-menu-unmark
-    "U" (if (< emacs-major-version 26)
-            'evil-collection-buff-menu-Buffer-menu-unmark-all
-          'Buffer-menu-unmark-all)
-    "m" 'Buffer-menu-mark
     "s" 'Buffer-menu-save
     [mouse-2] 'Buffer-menu-mouse-select
     [follow-link] 'mouse-face
@@ -91,6 +86,13 @@ When called interactively prompt for MARK;  RET remove all marks."
     "gv" 'Buffer-menu-select
     "gV" 'Buffer-menu-view
     "v" 'evil-visual-char
+
+    ;; mark
+    "u" 'Buffer-menu-unmark
+    "U" (if (< emacs-major-version 26)
+            'evil-collection-buff-menu-Buffer-menu-unmark-all
+          'Buffer-menu-unmark-all)
+    "m" 'Buffer-menu-mark
 
     "f" 'evil-find-char
     "e" 'evil-forward-word-end

--- a/evil-collection-calc.el
+++ b/evil-collection-calc.el
@@ -29,6 +29,8 @@
 (require 'evil)
 (require 'calc)
 
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
+
 (defun evil-collection-calc-ext-setup ()
   "Set up `evil' bindings for `calc'.
 Since calc bindings are set on-demand when calc-ext is load, we

--- a/evil-collection-elfeed.el
+++ b/evil-collection-elfeed.el
@@ -30,6 +30,10 @@
 (require 'elfeed nil t)
 (require 'evil)
 
+(defvar elfeed-search-mode-map)
+(defvar elfeed-show-mode-map)
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
+
 (defun evil-collection-elfeed-setup ()
   "Set up `evil' bindings for `elfeed'."
 

--- a/evil-collection-emms.el
+++ b/evil-collection-emms.el
@@ -32,6 +32,7 @@
 
 (declare-function emms-with-inhibit-read-only-t "emms")
 (declare-function emms-playlist-mode-correct-previous-yank "emms-playlist-mode")
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
 
 (defvar emms-browser-mode-map)
 (defvar emms-playlist-mode-map)

--- a/evil-collection-epa.el
+++ b/evil-collection-epa.el
@@ -34,8 +34,6 @@
 (defun evil-collection-epa-setup ()
   (evil-define-key 'normal epa-key-list-mode-map
     (kbd "<tab>") 'widget-forward
-    "m" 'epa-mark-key
-    "u" 'epa-unmark-key
     "gr" 'revert-buffer
     "q" 'epa-exit-buffer
     "E" 'epa-decrypt-file
@@ -43,6 +41,10 @@
     "ZZ" 'quit-window
     "ZQ" 'evil-quit
     "V" 'epa-verify-file
+
+    ;; mark
+    "m" 'epa-mark-key
+    "u" 'epa-unmark-key
 
     ;; Unchanged keybindings.
     "s" 'epa-sign-file

--- a/evil-collection-eww.el
+++ b/evil-collection-eww.el
@@ -30,6 +30,8 @@
 (require 'eww)
 (require 'evil)
 
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
+
 (defun evil-collection-eww-setup ()
   "Set up `evil' bindings for `eww'."
 

--- a/evil-collection-helm.el
+++ b/evil-collection-helm.el
@@ -41,6 +41,8 @@
 (defvar helm-map)
 (defvar helm-find-files-map)
 (defvar helm-read-file-map)
+(defvar helm-echo-input-in-header-line)
+(defvar helm--prompt)
 
 ;; From https://github.com/emacs-helm/helm/issues/362.
 ;; Also see https://emacs.stackexchange.com/questions/17058/change-cursor-type-in-helm-header-line#17097.

--- a/evil-collection-ibuffer.el
+++ b/evil-collection-ibuffer.el
@@ -40,15 +40,17 @@
                   'ibuffer-mark-for-delete-backwards))
 
   (evil-define-key 'normal ibuffer-mode-map
-    (kbd "m") 'ibuffer-mark-forward
-    (kbd "t") 'ibuffer-toggle-marks
-    (kbd "u") 'ibuffer-unmark-forward
     (kbd "=") 'ibuffer-diff-with-file
     (kbd "J") 'ibuffer-jump-to-buffer
     (kbd "M-g") 'ibuffer-jump-to-buffer
     (kbd "M-s a C-s") 'ibuffer-do-isearch
     (kbd "M-s a M-C-s") 'ibuffer-do-isearch-regexp
     (kbd "M-s a C-o") 'ibuffer-do-occur
+
+    ;; mark
+    (kbd "m") 'ibuffer-mark-forward
+    (kbd "~") 'ibuffer-toggle-marks
+    (kbd "u") 'ibuffer-unmark-forward
     (kbd "DEL") 'ibuffer-unmark-backward
     (kbd "M-DEL") 'ibuffer-unmark-all
     (kbd "* *") 'ibuffer-unmark-all
@@ -152,7 +154,7 @@
 
     (kbd "|") 'ibuffer-do-shell-command-pipe
     (kbd "!") 'ibuffer-do-shell-command-file
-    (kbd "~") 'ibuffer-do-toggle-modified
+    (kbd "t") 'ibuffer-do-toggle-modified
     ;; marked operations
     (kbd "A") 'ibuffer-do-view
     (kbd "D") 'ibuffer-do-delete

--- a/evil-collection-info.el
+++ b/evil-collection-info.el
@@ -32,6 +32,8 @@
 (require 'evil-collection-evil-search)
 (require 'info)
 
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
+
 (defun evil-collection-info-setup ()
   "Set up `evil' bindings for `info-mode'."
   (evil-collection-inhibit-insert-state Info-mode-map)

--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -185,7 +185,7 @@
     "m" 'tablist-mark-forward
     "~" 'tablist-toggle-marks
     "u" 'tablist-unmark-forward
-    "M" 'tablist-unmark-all-marks
+    "U" 'tablist-unmark-all-marks
     "*!" 'tablist-unmark-all-marks
     "*c" 'tablist-change-marks
     "*n" 'tablist-mark-items-numeric

--- a/evil-collection-pdf.el
+++ b/evil-collection-pdf.el
@@ -34,6 +34,10 @@
 (declare-function pdf-view-last-page "pdf-view")
 (declare-function pdf-view-first-page "pdf-view")
 (declare-function pdf-view-goto-page "pdf-view")
+(defvar pdf-view-mode-map)
+(defvar pdf-outline-buffer-mode-map)
+(defvar pdf-occur-buffer-mode-map)
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
 
 (defun evil-collection-pdf-view-goto-page (&optional page)
   "`evil' wrapper around `pdf-view-last-page'."

--- a/evil-collection-proced.el
+++ b/evil-collection-proced.el
@@ -30,6 +30,8 @@
 (require 'evil)
 (require 'proced)
 
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
+
 (defun evil-collection-proced-setup ()
   "Set up `evil' bindings for `proced'."
   (evil-collection-inhibit-insert-state proced-mode-map)

--- a/evil-collection-proced.el
+++ b/evil-collection-proced.el
@@ -41,7 +41,8 @@
     ;; TODO: Implement a proced-toggle-mark?
     "m" 'proced-mark ; Mentioned in documentation, should be followed.
     "*" 'proced-mark-all
-    "M" 'proced-unmark-all
+    "M" 'proced-mark-all
+    "U" 'proced-unmark-all
     "~" 'proced-toggle-marks
     "c" 'proced-mark-children
     "C" 'proced-mark-children ; Emacs has "C"

--- a/evil-collection-prodigy.el
+++ b/evil-collection-prodigy.el
@@ -41,7 +41,7 @@
     "gg" 'prodigy-first
     "G" 'prodigy-last
 
-    ;; TODO: Marking subject to change.
+    ;; mark
     "m" 'prodigy-mark
     "*t" 'prodigy-mark-tag
     "M" 'prodigy-mark-all

--- a/evil-collection-reftex.el
+++ b/evil-collection-reftex.el
@@ -43,11 +43,11 @@
 ;; original at reftex-ref.el
 (setq reftex-select-label-help
   " j / k      Go to next/previous label (Cursor motion works as well)
- [ / ]      Go to previous/next section heading.	
- c          Reuse last referenced label.	
+ [ / ]      Go to previous/next section heading.
+ c          Reuse last referenced label.
  J          Jump to a specific section, e.g. '3 J' jumps to section 3.
- s          Switch label type.	
- gr         Reparse document.	
+ s          Switch label type.
+ gr         Reparse document.
  go / gO     Show context / Show insertion point.
  S          Switch to label menu of external document (with LaTeX package `xr').
  r / R      Toggle \\ref <-> \\vref / Rotate \\ref <=> \\fref <=> \\Fref.
@@ -72,7 +72,7 @@
 
   (evil-set-initial-state 'reftex-select-label-mode 'normal)
   (evil-set-initial-state 'reftex-select-bib-mode 'normal)
-  
+
   (evil-define-key 'normal reftex-select-shared-map
     "j" 'reftex-select-next
     "k" 'reftex-select-previous
@@ -82,7 +82,7 @@
     (kbd "gk") 'reftex-select-previous-heading
     (kbd "C-j") 'reftex-select-next-heading
     (kbd "C-k") 'reftex-select-previous-heading
-    "go" 'reftex-select-callback ;shows the point where the label is
+    "go" 'reftex-select-callback        ;shows the point where the label is
     "gr" (lambda nil "Press `?' during selection to find out
     about this key" (interactive) (throw (quote myexit) 114)) ;reftex binds keys in a very arcane way using the number asigned by describe-char, in this case the value of "g" is 114
     "q" 'reftex-select-quit
@@ -95,9 +95,6 @@
     (kbd "<tab>") 'reftex-select-read-label
     "s" (lambda nil "Press `?' during selection to find out
     about this key." (interactive) (throw (quote myexit) 115))
-    "m" 'reftex-select-mark
-    "M" 'reftex-select-unmark ;a mark/unmark function would help here
-    "u" 'reftex-select-unmark ;does not causes problems with undo
     "x" (lambda nil "Press `?' during selection to find out
     about this key." (interactive) (throw (quote myexit) 97))
     "X" (lambda nil "Press `?' during selection to find out
@@ -106,14 +103,18 @@
     about this key." (interactive) (throw (quote myexit) 120))
     "r" 'reftex-select-cycle-ref-style-forward
     "R" 'reftex-select-cycle-ref-style-backward
-    "gO" 'reftex-select-show-insertion-point 
+    "gO" 'reftex-select-show-insertion-point
     "o" (lambda nil "Press `?' during selection to find out
     about this key." (interactive) (throw (quote myexit) 101))
     "O" (lambda nil "Press `?' during selection to find out
-    about this key." (interactive) (throw (quote myexit) 69)))
+    about this key." (interactive) (throw (quote myexit) 69))
+
+    ;; mark
+    "m" 'reftex-select-mark             ; TODO: Need a mark toggle function.
+    "u" 'reftex-select-unmark)
 
   (evil-set-initial-state 'reftex-toc-mode 'normal)
-  
+
   ;; This one is more involved, in reftex-toc.el, line 282 it shows the prompt
   ;; string with the keybinds and I don't see any way of changing it to show evil-like binds.
   (evil-define-key 'normal reftex-toc-mode-map

--- a/evil-collection-transmission.el
+++ b/evil-collection-transmission.el
@@ -31,6 +31,12 @@
 (require 'evil)
 (require 'transmission nil t)
 
+(defvar transmission-mode-map)
+(defvar transmission-files-mode-map)
+(defvar transmission-info-mode-map)
+(defvar transmission-peers-mode-map)
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
+
 (defun evil-collection-transmission-setup ()
   "Set up `evil' bindings for `transmission'."
 

--- a/evil-collection-transmission.el
+++ b/evil-collection-transmission.el
@@ -52,18 +52,18 @@
     "a" 'transmission-add
     ;; "D" 'transmission-delete ; Useless with `transmission-remove'?
     "r" 'transmission-move
-    "d" 'transmission-remove
+    "D" 'transmission-remove
     "x" 'transmission-toggle ; EMMS has "x" for pause.
     "t" 'transmission-trackers-add
     "c" 'transmission-verify ; "c" for "[c]heck".
-    "D" 'transmission-set-download
-    "U" 'transmission-set-upload
+    "d" 'transmission-set-download
+    "u" 'transmission-set-upload
     "S" 'transmission-set-ratio ; "S" for "[S]eed"
     "P" 'transmission-set-bandwidth-priority
 
     ;; mark
     "m" 'transmission-toggle-mark
-    "M" 'transmission-unmark-all
+    "U" 'transmission-unmark-all
     "~" 'transmission-invert-marks
 
     ;; refresh
@@ -88,9 +88,11 @@
     "i" 'transmission-info
 
     "r" 'transmission-move
-    "u" 'transmission-files-unwant
-    "U" 'transmission-files-want
     "P" 'transmission-files-priority
+
+    ;; mark
+    "u" 'transmission-files-unwant
+    "m" 'transmission-files-want
 
     ;; open
     (kbd "<return>") 'transmission-find-file

--- a/evil-collection-ztree.el
+++ b/evil-collection-ztree.el
@@ -29,6 +29,10 @@
 (require 'evil)
 (require 'ztree nil t)
 
+(declare-function evil-collection-inhibit-insert-state "evil-collection")
+(defvar ztree-mode-map)
+(defvar ztreediff-mode-map)
+
 (defun evil-collection-ztree-setup ()
   "Set up `evil' bindings for `ztree'."
 

--- a/readme.org
+++ b/readme.org
@@ -171,7 +171,7 @@ The rules are more-or-less sorted by priority.
 	- ~.~
 
 
-** Rationale (Work in progress)
+** Rationale
 
 Many special modes share the same set of similar actions.  Those actions should
 share the same bindings across all modes whenever feasible.
@@ -242,36 +242,32 @@ not seem to be any existing use of it, we leave the binding free for other uses.
 
 *** Marking
 
-Emacs inconsistently uses ~u~ and ~U~ to unmark.  Since in Vim those keys are
-usually bound to "undo", they are probably best left to commands that undo
-actions in the buffer and not undo marks.
-
 ~m~ defaults to ~evil-set-marker~ which might not be very useful in special
-modes.  This is somewhat debatable though.
-
-Suggested mark bindings:
+modes.
+~'~ can still be used as it can jump to other buffers.
 
 - ~m~: Mark or toggle mark, depending on what the mode offers.
+In visual mode, always mark.
+With a numeric argument, toggle mark on that many following lines.
+
+- ~u~: Unmark current selection.
+
+- ~U~: Unmark all.
 
 - =~=: Toggle all marks.  This mirrors the "invert-char" Vim command bound to =~=
 by default.
 
-- ~M~: Remove all marks.
+- ~M~: Mark all, if available.  Otherwise use =U~=.
+
+- ~*~: Mark-prefix or mark all if current mode has no prefix. ~*~ is traditionally a wildcard.
 
 - ~%~: Mark regexp.
 
 - ~x~: Execute action on marks.  This mirrors Dired's binding of ~x~.
 
-While ~m~ won't be available for setting marks (in the Vim sense), ~'~ can still
-be used as it can jump to other buffers.
+If ~*~ is used for marking, then ~#~ is free.
 
-Optionally:
-
-- ~*~: Mark all, because ~*~ is traditionally a wild card.
-
-- ~#~: Remove mark.  This is useful when we want to unmark a region having both
-marked and unmarked entries.  But ~M~ could also be made to remove all marks on
-region, making this binding useless.
+Also note that Emacs inconsistently uses ~u~ and ~U~ to unmark.
 
 *** Selecting / Filtering / Narrowing / Searching
 


### PR DESCRIPTION
Now that we've covered a decent number of modes, I've skimmed through them to see which bindings prevailed for marking.
It turns out that their was little deviation, so I've adjusted the few modes that showed inconsistencies.

(I might have missed a few, though.)

I've updated the rationale accordingly.  Let me know what you think.
